### PR TITLE
Fix vector printing tests in Python 2

### DIFF
--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sympy import symbols, sin, cos, sqrt, Function
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u_decode as u
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols
 from sympy.physics.vector.printing import (VectorPrettyPrinter,
                                            VectorLatexPrinter)


### PR DESCRIPTION
This uses u_decode instead of u, which is what the regular pretty printing
tests use.
